### PR TITLE
Use correct variable as input to `program_to_mlir`

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -588,7 +588,7 @@ def program_to_mlir(code: str) -> str:
     module = builtin.ModuleOp([])
     builder = Builder(InsertPoint.at_start(module.body.block))
 
-    parse_program(program, builder)
+    parse_program(code, builder)
 
     output = io.StringIO()
     Printer(stream=output).print_op(module)


### PR DESCRIPTION
The currently used variable is not defined in this function and just happens to be a global variable that is set. If used as a library, this does not work.